### PR TITLE
feat: add support for capturing responsive screenshots

### DIFF
--- a/src/Api/Concerns/InteractsWithScreen.php
+++ b/src/Api/Concerns/InteractsWithScreen.php
@@ -19,6 +19,20 @@ trait InteractsWithScreen
     }
 
     /**
+     * Performs a series of screenshots at different browser sizes to emulate different devices.
+     *
+     * @param  array<string, array{width: int, height: int}>  $responsiveScreenSizes
+     */
+    public function responsiveScreenshots(?string $filename = null, array $responsiveScreenSizes = []): self
+    {
+        $filename = $this->getFilename($filename);
+
+        $this->page->responsiveScreenshots($filename, $responsiveScreenSizes);
+
+        return $this;
+    }
+
+    /**
      * Performs a screenshot of an element and saves it to the given path.
      */
     public function screenshotElement(string $selector, ?string $filename = null): self

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -439,6 +439,23 @@ final class Page
     }
 
     /**
+     * Take a series of screenshots at different browser sizes to emulate different devices.
+     */
+    public function responsiveScreenshots(string $filename): self
+    {
+        if (mb_substr($filename, -1) !== '/') {
+            $filename .= '-';
+        }
+
+        foreach ($this->responsiveScreenSizes() as $device => $size) {
+            $this->setViewportSize($size['width'], $size['height'])
+                ->screenshot(filename: "$filename$device");
+        }
+
+        return $this;
+    }
+
+    /**
      * Make screenshot of a specific element.
      */
     public function screenshotElement(string $selector, ?string $filename = null): string
@@ -659,6 +676,41 @@ final class Page
             'caret' => 'hide',
             'animations' => 'disabled',
             'scale' => 'css',
+        ];
+    }
+
+    /**
+     * Returns the responsive screen sizes.
+     *
+     * @return array<string, array{width: int, height: int}>
+     */
+    private function responsiveScreenSizes(): array
+    {
+        return [
+            'xs' => [
+                'width' => 360,
+                'height' => 640,
+            ],
+            'sm' => [
+                'width' => 640,
+                'height' => 360,
+            ],
+            'md' => [
+                'width' => 768,
+                'height' => 1024,
+            ],
+            'lg' => [
+                'width' => 1024,
+                'height' => 768,
+            ],
+            'xl' => [
+                'width' => 1280,
+                'height' => 1024,
+            ],
+            '2xl' => [
+                'width' => 1536,
+                'height' => 864,
+            ],
         ];
     }
 

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -440,14 +440,20 @@ final class Page
 
     /**
      * Take a series of screenshots at different browser sizes to emulate different devices.
+     *
+     * @param  array<string, array{width: int, height: int}>  $responsiveScreenSizes
      */
-    public function responsiveScreenshots(string $filename): self
+    public function responsiveScreenshots(string $filename, array $responsiveScreenSizes = []): self
     {
         if (mb_substr($filename, -1) !== '/') {
             $filename .= '-';
         }
 
-        foreach ($this->responsiveScreenSizes() as $device => $size) {
+        if ($responsiveScreenSizes === []) {
+            $responsiveScreenSizes = $this->responsiveScreenSizes();
+        }
+
+        foreach ($responsiveScreenSizes as $device => $size) {
             $this->setViewportSize($size['width'], $size['height'])
                 ->screenshot(filename: "$filename$device");
         }

--- a/tests/Browser/Webpage/ScreenshotTest.php
+++ b/tests/Browser/Webpage/ScreenshotTest.php
@@ -42,3 +42,44 @@ it('captures a screenshot of an specific element', function (): void {
     expect(file_exists(Screenshot::path('element-screenshot.png')))
         ->toBeTrue();
 });
+
+it('captures responsive screenshots', function (): void {
+    Route::get('/', fn (): string => '<div>
+        <h1>Responsive Screenshot Test</h1>
+        <p>This page will be captured at different screen sizes</p>
+    </div>');
+
+    $page = visit('/');
+
+    $page->responsiveScreenshots(filename: 'responsive-test');
+
+    $devices = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+
+    foreach ($devices as $device) {
+        expect(file_exists(Screenshot::path("responsive-test-{$device}.png")))
+            ->toBeTrue();
+    }
+});
+
+it('captures responsive screenshots with custom screen sizes', function (): void {
+    Route::get('/', fn (): string => '<div>
+        <h1>Responsive Screenshot Test</h1>
+        <p>This page will be captured at different screen sizes</p>
+    </div>');
+
+    $page = visit('/');
+
+    $responsiveScreenSizes = [
+        'xs' => ['width' => 360, 'height' => 640],
+        'sm' => ['width' => 640, 'height' => 360],
+    ];
+
+    $page->responsiveScreenshots(filename: 'responsive-test', $responsiveScreenSizes);
+
+    $devices = array_keys($responsiveScreenSizes);
+
+    foreach ($devices as $device) {
+        expect(file_exists(Screenshot::path("responsive-test-{$device}.png")))
+            ->toBeTrue();
+    }
+});

--- a/tests/Browser/Webpage/ScreenshotTest.php
+++ b/tests/Browser/Webpage/ScreenshotTest.php
@@ -74,7 +74,7 @@ it('captures responsive screenshots with custom screen sizes', function (): void
         'sm' => ['width' => 640, 'height' => 360],
     ];
 
-    $page->responsiveScreenshots(filename: 'responsive-test', $responsiveScreenSizes);
+    $page->responsiveScreenshots(filename: 'responsive-test', responsiveScreenSizes: $responsiveScreenSizes);
 
     $devices = array_keys($responsiveScreenSizes);
 


### PR DESCRIPTION
This PR adds the ability to capture responsive screenshots of a page.

Example:

```php
$page = visit('/');

$page->responsiveScreenshots(filename: 'responsive-test');
```